### PR TITLE
Add root page handler

### DIFF
--- a/django_carlog/urls.py
+++ b/django_carlog/urls.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
 from django.urls import include, path
 
+from trips.views import HomeView
+
 
 urlpatterns = [
+    path("", HomeView.as_view(), name="home"),
     path("admin/", admin.site.urls),
     path("trips/", include("trips.urls")),
     path("accounts/", include("allauth.urls")),

--- a/trips/tests/test_views.py
+++ b/trips/tests/test_views.py
@@ -3,6 +3,7 @@
 from datetime import date
 from decimal import Decimal
 
+from django.contrib.auth.models import User
 from django.test import Client
 from django.urls import reverse
 
@@ -43,6 +44,30 @@ def sample_odometer(db, sample_car):
         car=sample_car,
         km=50000,
     )
+
+
+@pytest.fixture
+def user(db):
+    """Create a test user."""
+    return User.objects.create_user(username="testuser", password="testpass123")
+
+
+@pytest.mark.django_db
+class TestHomeView:
+    """Tests for the Home view (root page)."""
+
+    def test_home_redirects_unauthenticated_to_login(self, client):
+        """Test that unauthenticated users are redirected to login."""
+        response = client.get(reverse("home"))
+        assert response.status_code == 302
+        assert "accounts/login" in response.url
+
+    def test_home_redirects_authenticated_to_dashboard(self, client, user):
+        """Test that authenticated users are redirected to dashboard."""
+        client.login(username="testuser", password="testpass123")
+        response = client.get(reverse("home"))
+        assert response.status_code == 302
+        assert response.url == reverse("trips:dashboard")
 
 
 @pytest.mark.django_db

--- a/trips/views.py
+++ b/trips/views.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.db.models import Sum
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import (
     CreateView,
@@ -11,6 +12,7 @@ from django.views.generic import (
     ListView,
     TemplateView,
     UpdateView,
+    View,
 )
 
 from django_filters import rest_framework as filters
@@ -24,6 +26,20 @@ from trips.serializers import (
     TripSerializer,
     UserSerializer,
 )
+
+
+# =============================================================================
+# Home View (Root Page)
+# =============================================================================
+
+
+class HomeView(View):
+    """Root page - redirects authenticated users to dashboard, shows landing for others."""
+
+    def get(self, request):
+        if request.user.is_authenticated:
+            return redirect("trips:dashboard")
+        return redirect("account_login")
 
 
 # =============================================================================

--- a/trips/views.py
+++ b/trips/views.py
@@ -34,7 +34,7 @@ from trips.serializers import (
 
 
 class HomeView(View):
-    """Root page - redirects authenticated users to dashboard, shows landing for others."""
+    """Root page - redirects authenticated users to dashboard, unauthenticated users to login."""
 
     def get(self, request):
         if request.user.is_authenticated:


### PR DESCRIPTION
## Summary
- Adds a `HomeView` that handles the root URL path (`/`)
- Authenticated users are redirected to the dashboard (`/trips/`)
- Unauthenticated users are redirected to the login page
- Fixes the broken `LOGOUT_REDIRECT_URL = "/"` setting which previously caused a 404

## Test plan
- [ ] Visit root URL while logged out → should redirect to login
- [ ] Visit root URL while logged in → should redirect to dashboard
- [ ] Log out → should redirect to root, then to login (no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)